### PR TITLE
Ability to pause and resume recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 ## Changelogs
-- **[3.0.0-beta.1]**
-  - [iOS]
-    * Codebase re-written in `Swift`.
-    * Migrate `AVAudioPlayer` to `AVPlayer`.
+- **[3.0.0]**
+  - 3.0.0-beta.2
+    - Add `resumeRecorder` and `pauseRecorder` features.
+      - **Caveat**: Android now requires min sdk of `24`.
+    - Renamed listener callback variables from `snake_case` to `camelCase`.
+      * Below are return types.
+        ```ts
+        export type RecordBackType = {
+          isRecording?: boolean;
+          currentPosition: number;
+          currentMetering?: number;
+        };
+
+        export type PlayBackType = {
+          isMuted?: boolean;
+          currentPosition: number;
+          duration: number;
+        };
+        ```
+  - 3.0.0-beta.1
+    - [iOS]
+      * Codebase re-written in `Swift`.
+      * Migrate `AVAudioPlayer` to `AVPlayer`.
+
 - **[2.7.0]**
   - Migrate `android` module to `kotlin`.
 - **[2.6.2]**

--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -7,8 +7,10 @@ import AudioRecorderPlayer, {
 } from 'react-native-audio-recorder-player';
 import {
   Dimensions,
+  NativeModules,
   PermissionsAndroid,
   Platform,
+  SafeAreaView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -144,7 +146,7 @@ class Page extends Component<any, State> {
     }
 
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <Text style={styles.titleTxt}>Audio Recorder Player</Text>
         <Text style={styles.txtRecordCounter}>{this.state.recordTime}</Text>
         <View style={styles.viewRecorder}>
@@ -154,6 +156,28 @@ class Page extends Component<any, State> {
               onPress={this.onStartRecord}
               textStyle={styles.txt}>
               Record
+            </Button>
+            <Button
+              style={[
+                styles.btn,
+                {
+                  marginLeft: 12,
+                },
+              ]}
+              onPress={this.onPauseRecord}
+              textStyle={styles.txt}>
+              Pause
+            </Button>
+            <Button
+              style={[
+                styles.btn,
+                {
+                  marginLeft: 12,
+                },
+              ]}
+              onPress={this.onResumeRecord}
+              textStyle={styles.txt}>
+              Resume
             </Button>
             <Button
               style={[styles.btn, {marginLeft: 12}]}
@@ -199,13 +223,24 @@ class Page extends Component<any, State> {
                   marginLeft: 12,
                 },
               ]}
+              onPress={this.onResumePlay}
+              textStyle={styles.txt}>
+              Resume
+            </Button>
+            <Button
+              style={[
+                styles.btn,
+                {
+                  marginLeft: 12,
+                },
+              ]}
               onPress={this.onStopPlay}
               textStyle={styles.txt}>
               Stop
             </Button>
           </View>
         </View>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -277,13 +312,21 @@ class Page extends Component<any, State> {
 
     this.audioRecorderPlayer.addRecordBackListener((e: any) => {
       this.setState({
-        recordSecs: e.current_position,
+        recordSecs: e.currentPosition,
         recordTime: this.audioRecorderPlayer.mmssss(
-          Math.floor(e.current_position),
+          Math.floor(e.currentPosition),
         ),
       });
     });
     console.log(`uri: ${uri}`);
+  };
+
+  private onPauseRecord = async () => {
+    await NativeModules.RNAudioRecorderPlayer.pauseRecorder();
+  };
+
+  private onResumeRecord = async () => {
+    await NativeModules.RNAudioRecorderPlayer.resumeRecorder();
   };
 
   private onStopRecord = async () => {
@@ -302,15 +345,15 @@ class Page extends Component<any, State> {
     console.log(`file: ${msg}`, `volume: ${volume}`);
 
     this.audioRecorderPlayer.addPlayBackListener((e: any) => {
-      if (e.current_position === e.duration) {
+      if (e.currentPosition === e.duration) {
         console.log('finished');
         this.audioRecorderPlayer.stopPlayer();
       }
       this.setState({
-        currentPositionSec: e.current_position,
+        currentPositionSec: e.currentPosition,
         currentDurationSec: e.duration,
         playTime: this.audioRecorderPlayer.mmssss(
-          Math.floor(e.current_position),
+          Math.floor(e.currentPosition),
         ),
         duration: this.audioRecorderPlayer.mmssss(Math.floor(e.duration)),
       });
@@ -319,6 +362,10 @@ class Page extends Component<any, State> {
 
   private onPausePlay = async () => {
     await this.audioRecorderPlayer.pausePlayer();
+  };
+
+  private onResumePlay = async () => {
+    await this.audioRecorderPlayer.resumePlayer();
   };
 
   private onStopPlay = async () => {

--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -4,10 +4,11 @@ import AudioRecorderPlayer, {
   AudioEncoderAndroidType,
   AudioSet,
   AudioSourceAndroidType,
+  PlayBackType,
+  RecordBackType,
 } from 'react-native-audio-recorder-player';
 import {
   Dimensions,
-  NativeModules,
   PermissionsAndroid,
   Platform,
   SafeAreaView,
@@ -310,7 +311,7 @@ class Page extends Component<any, State> {
       audioSet,
     );
 
-    this.audioRecorderPlayer.addRecordBackListener((e: any) => {
+    this.audioRecorderPlayer.addRecordBackListener((e: RecordBackType) => {
       this.setState({
         recordSecs: e.currentPosition,
         recordTime: this.audioRecorderPlayer.mmssss(
@@ -322,11 +323,15 @@ class Page extends Component<any, State> {
   };
 
   private onPauseRecord = async () => {
-    await NativeModules.RNAudioRecorderPlayer.pauseRecorder();
+    try {
+      await this.audioRecorderPlayer.pauseRecorder();
+    } catch (err) {
+      console.log('pauseRecord', err);
+    }
   };
 
   private onResumeRecord = async () => {
-    await NativeModules.RNAudioRecorderPlayer.resumeRecorder();
+    await this.audioRecorderPlayer.resumeRecorder();
   };
 
   private onStopRecord = async () => {
@@ -344,7 +349,7 @@ class Page extends Component<any, State> {
     const volume = await this.audioRecorderPlayer.setVolume(1.0);
     console.log(`file: ${msg}`, `volume: ${volume}`);
 
-    this.audioRecorderPlayer.addPlayBackListener((e: any) => {
+    this.audioRecorderPlayer.addPlayBackListener((e: PlayBackType) => {
       if (e.currentPosition === e.duration) {
         console.log('finished');
         this.audioRecorderPlayer.stopPlayer();

--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     ext {
         buildToolsVersion = "29.0.3"
-        minSdkVersion = 21
+        minSdkVersion = 24
         compileSdkVersion = 29
         targetSdkVersion = 29
         ndkVersion = "20.1.5948944"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ This is a react-native link module for audio recorder and player. This is not a 
   1. Codebase has been re-written to [kotlin for Android](https://kotlinlang.org) and [swift for iOS](https://swift.org).
   [iOS]
   * [AVAudioPlayer](https://developer.apple.com/documentation/avfaudio/avaudioplayer) has been migrated to [AVPlayer](https://developer.apple.com/documentation/avfoundation/avplayer) which supports stream and more possibilities [#231](https://github.com/hyochan/react-native-audio-recorder-player/issues/231), [#245](https://github.com/hyochan/react-native-audio-recorder-player/issues/245), [#275](https://github.com/hyochan/react-native-audio-recorder-player/issues/275).
+  2. `pauseRecorder` and `resumeRecorder` features are added.
+     - **Caveat** Android now requires `minSdk` of `24`.
+  3. Renamed callback variables.
+      ```ts
+      export type RecordBackType = {
+        isRecording?: boolean;
+        currentPosition: number;
+        currentMetering?: number;
+      };
+
+      export type PlayBackType = {
+        isMuted?: boolean;
+        currentPosition: number;
+        duration: number;
+      };
+      ```
 
 - There has been vast improvements in [#114](https://github.com/dooboolab/react-native-audio-recorder-player/pull/114) which is released in `2.3.0`. We now support all `RN` versions without any version differenciating. See below installation guide for your understanding.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This is a react-native link module for audio recorder and player. This is not a 
 | 1.x.x                  | 2.x.x & 3.x.x             |
 | ---------------------- | ------------------------- |
 | `startRecord`          | `startRecorder`           |
+|                        | `pauseRecorder`  (3.x.x)  |
+|                        | `resumeRecorder` (3.x.x)  |
 | `stopRecord`           | `stopRecorder`            |
 | `startPlay`            | `startPlayer`             |
 | `stopPlay`             | `stopPlayer`              |
@@ -178,9 +180,10 @@ All methods are implemented with promises.
 | Func                  |        Param        |      Return       | Description                                                                  |
 | :-------------------- | :--------------------: | :---------------: | :--------------------------------------------------------------------------- |
 | mmss                  |  `number` seconds       |     `string`      | Convert seconds to `minute:second` string.                                   |
-| addRecordBackListener | `Function` callBack     |     `void`        | Get callback from native module. Will receive `current_position`, `current_metering` (if configured in startRecorder)          |
-| addPlayBackListener   | `Function` callBack     |      `void`       | Get callback from native module. Will receive `duration`, `current_position` |
+| addRecordBackListener | `Function` callBack     |     `void`        | Get callback from native module. Will receive `currentPosition`, `currentMetering` (if configured in startRecorder)          |
+| addPlayBackListener   | `Function` callBack     |      `void`       | Get callback from native module. Will receive `duration`, `currentPosition` |
 | startRecorder         |   `<string>` uri? `<boolean>` meteringEnabled?      |  `Promise<void>`  | Start recording. Not passing uri will save audio in default location.  |
+| pauseRecorder         |                         | `Promise<string>` | Pause recording.                                                              |
 | stopRecorder          |                         | `Promise<string>` | Stop recording.                                                              |
 | startPlayer           |   `string` uri? `Record<string, string>` httpHeaders?       | `Promise<string>` | Start playing. Not passing the param will play audio in default location.    |
 | stopPlayer            |                         | `Promise<string>` | Stop playing.                                                                |
@@ -218,9 +221,9 @@ interface AudioSet {
     
     this.audioRecorderPlayer.addRecordBackListener((e: any) => {
       this.setState({
-        recordSecs: e.current_position,
+        recordSecs: e.currentPosition,
         recordTime: this.audioRecorderPlayer.mmssss(
-          Math.floor(e.current_position),
+          Math.floor(e.currentPosition),
         ),
       });
     });
@@ -242,9 +245,9 @@ onStartRecord = async () => {
   const result = await this.audioRecorderPlayer.startRecorder();
   this.audioRecorderPlayer.addRecordBackListener((e) => {
     this.setState({
-      recordSecs: e.current_position,
+      recordSecs: e.currentPosition,
       recordTime: this.audioRecorderPlayer.mmssss(
-        Math.floor(e.current_position),
+        Math.floor(e.currentPosition),
       ),
     });
     return;
@@ -267,9 +270,9 @@ onStartPlay = async () => {
   console.log(msg);
   this.audioRecorderPlayer.addPlayBackListener((e) => {
     this.setState({
-      currentPositionSec: e.current_position,
+      currentPositionSec: e.currentPosition,
       currentDurationSec: e.duration,
-      playTime: this.audioRecorderPlayer.mmssss(Math.floor(e.current_position)),
+      playTime: this.audioRecorderPlayer.mmssss(Math.floor(e.currentPosition)),
       duration: this.audioRecorderPlayer.mmssss(Math.floor(e.duration)),
     });
     return;

--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -76,7 +76,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                 override fun run() {
                     val time = SystemClock.elapsedRealtime() - systemTime
                     val obj = Arguments.createMap()
-                    obj.putDouble("current_position", time.toDouble())
+                    obj.putDouble("currentPosition", time.toDouble())
                     if (_meteringEnabled) {
                         var maxAmplitude = 0
                         if (mediaRecorder != null) {
@@ -87,7 +87,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                         if (maxAmplitude > 0) {
                             dB = 20 * log10(maxAmplitude / maxAudioSize)
                         }
-                        obj.putInt("current_metering", dB.toInt())
+                        obj.putInt("currentMetering", dB.toInt())
                     }
                     sendEvent(reactContext, "rn-recordback", obj)
                     recordHandler!!.postDelayed(this, subsDurationMillis.toLong())
@@ -174,7 +174,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                     override fun run() {
                         val obj = Arguments.createMap()
                         obj.putInt("duration", mp.duration)
-                        obj.putInt("current_position", mp.currentPosition)
+                        obj.putInt("currentPosition", mp.currentPosition)
                         sendEvent(reactContext, "rn-playback", obj)
                     }
                 }
@@ -193,7 +193,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                  */
                 val obj = Arguments.createMap()
                 obj.putInt("duration", mp.duration)
-                obj.putInt("current_position", mp.duration)
+                obj.putInt("currentPosition", mp.duration)
                 sendEvent(reactContext, "rn-playback", obj)
                 /**
                  * Reset player.

--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -20,13 +20,15 @@ import kotlin.math.log10
 
 class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext), PermissionListener {
     private var audioFileURL = ""
-    private var subsDurationMillis = 100
+    private var subsDurationMillis = 500
     private var _meteringEnabled = false
     private var mediaRecorder: MediaRecorder? = null
     private var mediaPlayer: MediaPlayer? = null
     private var recorderRunnable: Runnable? = null
     private var mTask: TimerTask? = null
     private var mTimer: Timer? = null
+    private var pausedRecordTime = 0L
+    private var totalPausedRecordTime = 0L
     var recordHandler: Handler? = Handler(Looper.getMainLooper())
     override fun getName(): String {
         return tag
@@ -51,9 +53,11 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         }
         audioFileURL = if (((path == "DEFAULT"))) fileLocation else path
         _meteringEnabled = meteringEnabled
+
         if (mediaRecorder == null) {
             mediaRecorder = MediaRecorder()
         }
+
         if (audioSet != null) {
             mediaRecorder!!.setAudioSource(if (audioSet.hasKey("AudioSourceAndroid")) audioSet.getInt("AudioSourceAndroid") else MediaRecorder.AudioSource.MIC)
             mediaRecorder!!.setOutputFormat(if (audioSet.hasKey("OutputFormatAndroid")) audioSet.getInt("OutputFormatAndroid") else MediaRecorder.OutputFormat.MPEG_4)
@@ -68,13 +72,15 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             mediaRecorder!!.setAudioSamplingRate(48000)
         }
         mediaRecorder!!.setOutputFile(audioFileURL)
+
         try {
             mediaRecorder!!.prepare()
+            totalPausedRecordTime = 0L
             mediaRecorder!!.start()
             val systemTime = SystemClock.elapsedRealtime()
             recorderRunnable = object : Runnable {
                 override fun run() {
-                    val time = SystemClock.elapsedRealtime() - systemTime
+                    val time = SystemClock.elapsedRealtime() - systemTime - totalPausedRecordTime
                     val obj = Arguments.createMap()
                     obj.putDouble("currentPosition", time.toDouble())
                     if (_meteringEnabled) {
@@ -98,6 +104,42 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         } catch (e: Exception) {
             Log.e(tag, "Exception: ", e)
             promise.reject("startRecord", e.message)
+        }
+    }
+
+    @ReactMethod
+    fun resumeRecorder(promise: Promise) {
+        if (mediaRecorder == null) {
+            promise.reject("resumeReocrder", "Recorder is null.")
+            return
+        }
+
+        try {
+            mediaRecorder!!.resume()
+            totalPausedRecordTime += SystemClock.elapsedRealtime() - pausedRecordTime;
+            recordHandler!!.postDelayed(recorderRunnable, subsDurationMillis.toLong())
+            promise.resolve("Recorder resumed.")
+        } catch (e: Exception) {
+            Log.e(tag, "Recorder resume: " + e.message)
+            promise.reject("resumeRecorder", e.message)
+        }
+    }
+
+    @ReactMethod
+    fun pauseRecorder(promise: Promise) {
+        if (mediaRecorder == null) {
+            promise.reject("pauseRecorder", "Recorder is null.")
+            return
+        }
+
+        try {
+            mediaRecorder!!.pause()
+            pausedRecordTime = SystemClock.elapsedRealtime();
+            recordHandler!!.removeCallbacks(recorderRunnable);
+            promise.resolve("Recorder paused.")
+        } catch (e: Exception) {
+            Log.e(tag, "pauseRecorder exception: " + e.message)
+            promise.reject("pauseRecorder", e.message)
         }
     }
 
@@ -127,6 +169,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             promise.reject("setVolume", "player is null.")
             return
         }
+
         val mVolume = volume.toFloat()
         mediaPlayer!!.setVolume(mVolume, mVolume)
         promise.resolve("set volume")
@@ -136,11 +179,13 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     fun startPlayer(path: String, httpHeaders: ReadableMap?, promise: Promise) {
         if (mediaPlayer != null) {
             val isPaused = !mediaPlayer!!.isPlaying && mediaPlayer!!.currentPosition > 1
+
             if (isPaused) {
                 mediaPlayer!!.start()
                 promise.resolve("player resumed.")
                 return
             }
+
             Log.e(tag, "Player is already running. Stop it first.")
             promise.reject("startPlay", "Player is already running. Stop it first.")
             return
@@ -164,6 +209,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                     mediaPlayer!!.setDataSource(path)
                 }
             }
+
             mediaPlayer!!.setOnPreparedListener { mp ->
                 Log.d(tag, "mediaplayer prepared and start")
                 mp.start()
@@ -178,6 +224,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                         sendEvent(reactContext, "rn-playback", obj)
                     }
                 }
+
                 mTimer = Timer()
                 mTimer!!.schedule(mTask, 0, subsDurationMillis.toLong())
                 val resolvedPath = if (((path == "DEFAULT"))) "file:///$fileLocation" else path
@@ -204,6 +251,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                 mp.release()
                 mediaPlayer = null
             }
+
             mediaPlayer!!.prepare()
         } catch (e: IOException) {
             Log.e(tag, "startPlay() io exception")
@@ -219,10 +267,12 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             promise.reject("resume", "mediaPlayer is null.")
             return
         }
+
         if (mediaPlayer!!.isPlaying) {
             promise.reject("resume", "mediaPlayer is already running.")
             return
         }
+
         try {
             mediaPlayer!!.seekTo(mediaPlayer!!.currentPosition)
             mediaPlayer!!.start()
@@ -239,6 +289,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             promise.reject("pausePlay", "mediaPlayer is null.")
             return
         }
+
         try {
             mediaPlayer!!.pause()
             promise.resolve("pause player")
@@ -254,6 +305,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             promise.reject("seekTo", "mediaPlayer is null.")
             return
         }
+
         val millis = time * 1000
         mediaPlayer!!.seekTo(millis)
         promise.resolve("pause player")
@@ -296,9 +348,11 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray): Boolean {
         var requestRecordAudioPermission: Int = 200
+
         when (requestCode) {
             requestRecordAudioPermission -> if (grantResults[0] == PackageManager.PERMISSION_GRANTED) return true
         }
+
         return false
     }
 

--- a/index.ts
+++ b/index.ts
@@ -112,10 +112,23 @@ const pad = (num: number): string => {
   return ('0' + num).slice(-2);
 };
 
+type RecordBackType = {
+  isRecording?: boolean;
+  currentPosition: number;
+  currentMetering?: number;
+};
+
+type PlayBackType = {
+  isMuted?: boolean;
+  currentPosition: number;
+  duration: number;
+};
+
 class AudioRecorderPlayer {
   private _isRecording: boolean;
   private _isPlaying: boolean;
   private _hasPaused: boolean;
+  private _hasPausedRecord: boolean;
   private _recorderSubscription: EmitterSubscription;
   private _playerSubscription: EmitterSubscription;
   private _recordInterval: number;
@@ -126,8 +139,6 @@ class AudioRecorderPlayer {
     secs = secs % 60;
     minutes = minutes % 60;
 
-    // minutes = ('0' + minutes).slice(-2);
-    // secs = ('0' + secs).slice(-2);
     return pad(minutes) + ':' + pad(secs);
   };
 
@@ -141,24 +152,26 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * set listerner from native module for recorder.
-   * @returns {callBack(e: any)}
+   * Set listerner from native module for recorder.
+   * @returns {callBack(e: RecordBackType)}
    */
-  addRecordBackListener = (e): void => {
+  addRecordBackListener = (e: RecordBackType): void => {
     if (Platform.OS === 'android')
       this._recorderSubscription = DeviceEventEmitter.addListener(
         'rn-recordback',
+        // @ts-ignore
         e,
       );
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
+      // @ts-ignore
       this._recorderSubscription = myModuleEvt.addListener('rn-recordback', e);
     }
   };
 
   /**
-   * remove listener for recorder.
+   * Remove listener for recorder.
    * @returns {void}
    */
   removeRecordBackListener = (): void => {
@@ -169,18 +182,20 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * set listener from native module for player.
-   * @returns {callBack(e: Event)}
+   * Set listener from native module for player.
+   * @returns {callBack(e: PlayBackType)}
    */
-  addPlayBackListener = (e): void => {
+  addPlayBackListener = (e: PlayBackType): void => {
     if (Platform.OS === 'android')
       this._playerSubscription = DeviceEventEmitter.addListener(
         'rn-playback',
+        // @ts-ignore
         e,
       );
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
+      // @ts-ignore
       this._playerSubscription = myModuleEvt.addListener('rn-playback', e);
     }
   };
@@ -220,6 +235,36 @@ class AudioRecorderPlayer {
   };
 
   /**
+   * Pause recording.
+   * @returns {Promise<string>}
+   */
+  pauseRecorder = async (): Promise<string> => {
+    if (!this._isRecording) return 'No audio recording';
+
+    if (!this._hasPausedRecord) {
+      this._hasPausedRecord = true;
+
+      return RNAudioRecorderPlayer.pauseRecorder();
+    }
+  };
+
+  /**
+   * Resume recording.
+   * @returns {Promise<string>}
+   */
+  resumeRecorder = async (): Promise<string> => {
+    if (!this._isRecording) return 'No audio recording';
+
+    if (this._isRecording) {
+      this._isRecording = true;
+
+      return RNAudioRecorderPlayer.resumeRecorder();
+    }
+
+    return 'Already recording';
+  };
+
+  /**
    * stop recording.
    * @returns {Promise<string>}
    */
@@ -234,7 +279,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * resume playing.
+   * Resume playing.
    * @returns {Promise<string>}
    */
   resumePlayer = async (): Promise<string> => {
@@ -250,7 +295,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * start playing with param.
+   * Start playing with param.
    * @param {string} uri audio uri.
    * @param {Record<string, string>} httpHeaders Set of http headers.
    * @returns {Promise<string>}
@@ -273,7 +318,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * stop playing.
+   * Stop playing.
    * @returns {Promise<string>}
    */
   stopPlayer = async (): Promise<string> => {
@@ -288,7 +333,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * pause playing.
+   * Pause playing.
    * @returns {Promise<string>}
    */
   pausePlayer = async (): Promise<string> => {
@@ -302,7 +347,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * seek to.
+   * Seek to.
    * @param {number} time position seek to in second.
    * @returns {Promise<string>}
    */
@@ -313,7 +358,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * set volume.
+   * Set volume.
    * @param {number} setVolume set volume.
    * @returns {Promise<string>}
    */
@@ -325,7 +370,7 @@ class AudioRecorderPlayer {
   };
 
   /**
-   * set subscription duration.
+   * Set subscription duration. Default is 0.5.
    * @param {number} sec subscription callback duration in seconds.
    * @returns {Promise<string>}
    */

--- a/index.ts
+++ b/index.ts
@@ -112,13 +112,13 @@ const pad = (num: number): string => {
   return ('0' + num).slice(-2);
 };
 
-type RecordBackType = {
+export type RecordBackType = {
   isRecording?: boolean;
   currentPosition: number;
   currentMetering?: number;
 };
 
-type PlayBackType = {
+export type PlayBackType = {
   isMuted?: boolean;
   currentPosition: number;
   duration: number;
@@ -239,13 +239,13 @@ class AudioRecorderPlayer {
    * @returns {Promise<string>}
    */
   pauseRecorder = async (): Promise<string> => {
-    if (!this._isRecording) return 'No audio recording';
-
     if (!this._hasPausedRecord) {
       this._hasPausedRecord = true;
 
       return RNAudioRecorderPlayer.pauseRecorder();
     }
+
+    return 'Already paused recording.';
   };
 
   /**
@@ -253,15 +253,13 @@ class AudioRecorderPlayer {
    * @returns {Promise<string>}
    */
   resumeRecorder = async (): Promise<string> => {
-    if (!this._isRecording) return 'No audio recording';
-
-    if (this._isRecording) {
-      this._isRecording = true;
+    if (this._hasPausedRecord) {
+      this._hasPausedRecord = false;
 
       return RNAudioRecorderPlayer.resumeRecorder();
     }
 
-    return 'Already recording';
+    return 'Currently recording.';
   };
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -153,7 +153,7 @@ class AudioRecorderPlayer {
 
   /**
    * Set listerner from native module for recorder.
-   * @returns {callBack(e: RecordBackType)}
+   * @returns {callBack((e: RecordBackType): void)}
    */
   addRecordBackListener = (e: RecordBackType): void => {
     if (Platform.OS === 'android')
@@ -183,7 +183,7 @@ class AudioRecorderPlayer {
 
   /**
    * Set listener from native module for player.
-   * @returns {callBack(e: PlayBackType)}
+   * @returns {callBack((e: PlayBackType): void)}
    */
   addPlayBackListener = (e: PlayBackType): void => {
     if (Platform.OS === 'android')

--- a/ios/RNAudioRecorderPlayer.h
+++ b/ios/RNAudioRecorderPlayer.h
@@ -7,5 +7,4 @@
 - (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player
         successfully:(BOOL)flag;
 - (void)updateRecorderProgress:(NSTimer*) timer;
-- (void)updateProgress:(NSTimer*) timer;
 @end

--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -20,6 +20,11 @@ RCT_EXTERN_METHOD(startRecorder:(NSString *)path
 RCT_EXTERN_METHOD(stopRecorder:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(pauseRecorder:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
+
+RCT_EXTERN_METHOD(resumeRecorder:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(setVolume:(float)volume
                   resolve:(RCTPromiseResolveBlock) resolve

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -33,7 +33,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
     override func supportedEvents() -> [String]! {
         return ["rn-playback", "rn-recordback"]
     }
-    
+
     func setAudioFileURL(path: String) {
         if (path == "DEFAULT") {
             let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
@@ -45,7 +45,9 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
             audioFileURL = cachesDirectory.appendingPathComponent(path)
         }
     }
-    
+
+    /**********               Recorder               **********/
+
     @objc(updateRecorderProgress:)
     public func updateRecorderProgress(timer: Timer) -> Void {
         if (audioRecorder != nil) {
@@ -77,6 +79,40 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                 repeats: true
             )
         }
+    }
+
+    @objc(pauseRecorder:rejecter:)
+    public func pauseRecorder(
+        resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        if (audioRecorder == nil) {
+            return reject("RNAudioPlayerRecorder", "Recorder is not recording", nil)
+        }
+
+        recordTimer?.invalidate()
+        recordTimer = nil;
+
+        audioRecorder.pause()
+        resolve("Recorder paused!")
+    }
+
+    @objc(resumeRecorder:rejecter:)
+    public func resumeRecorder(
+        resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) -> Void {
+        if (audioRecorder == nil) {
+            return reject("RNAudioPlayerRecorder", "Recorder is nil", nil)
+        }
+
+        audioRecorder.record()
+
+        if (recordTimer == nil) {
+            startRecorderTimer()
+        }
+
+        resolve("Recorder paused!")
     }
 
     @objc
@@ -307,7 +343,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         }
 
         audioPlayer.pause()
-        resolve("Paused!")
+        resolve("Player paused!")
     }
 
     @objc(resumePlayer:rejecter:)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-recorder-player",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "React Native Audio Recorder and Player.",
   "homepage": "https://github.com/dooboolab/react-native-audio-recorder-player",
   "main": "index.ts",


### PR DESCRIPTION
- Add `resumeRecorder` and `pauseRecorder` features.
   - **Caveat**: Android now requires min sdk of `24`.
- Renamed listener callback variables from `snake_case` to `camelCase`.
   * Below are return types.
      ```ts
      export type RecordBackType = {
        isRecording?: boolean;
        currentPosition: number;
        currentMetering?: number;
      };

      export type PlayBackType = {
        isMuted?: boolean;
        currentPosition: number;
        duration: number;
      };
      ```

Closes #15
Closes #268 


Co-authored-by: PatrickNies <patrick.nies@waysofsolutions.de>