### PR TITLE
before setActive should stop RNAudioRecorderPlayer

### DIFF
--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -256,9 +256,8 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
     ) -> Void {
         if (audioRecorder != nil) {
             do {
-                try recordingSession.setActive(false)
-
                 audioRecorder.stop()
+                try recordingSession.setActive(false)
 
                 if (recordTimer != nil) {
                     recordTimer!.invalidate()


### PR DESCRIPTION
iOS 14.5.1 error