### PR TITLE
Add optional wrappers to support android sdk 30

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -117,7 +117,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         try {
             mediaRecorder!!.resume()
             totalPausedRecordTime += SystemClock.elapsedRealtime() - pausedRecordTime;
-            recordHandler!!.postDelayed(recorderRunnable, subsDurationMillis.toLong())
+            recorderRunnable?.let { recordHandler!!.postDelayed(it, subsDurationMillis.toLong()) }
             promise.resolve("Recorder resumed.")
         } catch (e: Exception) {
             Log.e(tag, "Recorder resume: " + e.message)
@@ -135,7 +135,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         try {
             mediaRecorder!!.pause()
             pausedRecordTime = SystemClock.elapsedRealtime();
-            recordHandler!!.removeCallbacks(recorderRunnable);
+            recorderRunnable?.let { recordHandler!!.removeCallbacks(it) };
             promise.resolve("Recorder paused.")
         } catch (e: Exception) {
             Log.e(tag, "pauseRecorder exception: " + e.message)
@@ -146,7 +146,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     @ReactMethod
     fun stopRecorder(promise: Promise) {
         if (recordHandler != null) {
-            recordHandler!!.removeCallbacks(recorderRunnable)
+            recorderRunnable?.let { recordHandler!!.removeCallbacks(it) }
         }
         if (mediaRecorder == null) {
             promise.reject("stopRecord", "recorder is null.")
@@ -155,7 +155,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         try {
             mediaRecorder!!.stop()
         } catch (stopException: RuntimeException) {
-            Log.d(tag, stopException.message)
+            stopException.message?.let { Log.d(tag, it) }
             promise.reject("stopRecord", stopException.message)
         }
         mediaRecorder!!.release()


### PR DESCRIPTION
When compiling the project with the following config:

```
compileSdkVersion = 30
targetSdkVersion = 30
```

An error occurs while trying to make a build for android. Its message is the following:

```
Error: Command failed: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
e: <project-path>/node_modules/react-native-audio-recorder-player/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt: (120, 41): Type mismatch: inferred type is Runnable? but Runnable was expected
e: <project-path>/node_modules/react-native-audio-recorder-player/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt: (138, 45): Type mismatch: inferred type is Runnable? but Runnable was expected
e: <project-path>/node_modules/react-native-audio-recorder-player/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt: (149, 45): Type mismatch: inferred type is Runnable? but Runnable was expected
e: <project-path>/node_modules/react-native-audio-recorder-player/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt: (158, 24): Type mismatch: inferred type is String? but String was expected
```

This pull request just added a `let` wrapper over the variables that were causing the crash.