### PR TITLE
Update types in listener functions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -155,18 +155,17 @@ class AudioRecorderPlayer {
    * Set listerner from native module for recorder.
    * @returns {callBack((e: RecordBackType): void)}
    */
-  addRecordBackListener = (e: RecordBackType): void => {
+
+  addRecordBackListener =  (callback: ((recordingMeta: RecordBackType) => void)): void => {
     if (Platform.OS === 'android')
       this._recorderSubscription = DeviceEventEmitter.addListener(
         'rn-recordback',
-        // @ts-ignore
-        e,
+        callback,
       );
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
-      // @ts-ignore
-      this._recorderSubscription = myModuleEvt.addListener('rn-recordback', e);
+      this._recorderSubscription = myModuleEvt.addListener('rn-recordback', callback);
     }
   };
 
@@ -185,18 +184,16 @@ class AudioRecorderPlayer {
    * Set listener from native module for player.
    * @returns {callBack((e: PlayBackType): void)}
    */
-  addPlayBackListener = (e: PlayBackType): void => {
+  addPlayBackListener = (callback: ((playbackMeta: PlayBackType) => void)): void => {
     if (Platform.OS === 'android')
       this._playerSubscription = DeviceEventEmitter.addListener(
         'rn-playback',
-        // @ts-ignore
-        e,
+        callback,
       );
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
-      // @ts-ignore
-      this._playerSubscription = myModuleEvt.addListener('rn-playback', e);
+      this._playerSubscription = myModuleEvt.addListener('rn-playback', callback);
     }
   };
 

--- a/index.ts
+++ b/index.ts
@@ -156,7 +156,9 @@ class AudioRecorderPlayer {
    * @returns {callBack((e: RecordBackType): void)}
    */
 
-  addRecordBackListener =  (callback: ((recordingMeta: RecordBackType) => void)): void => {
+  addRecordBackListener = (
+    callback: (recordingMeta: RecordBackType) => void,
+  ): void => {
     if (Platform.OS === 'android')
       this._recorderSubscription = DeviceEventEmitter.addListener(
         'rn-recordback',
@@ -165,7 +167,10 @@ class AudioRecorderPlayer {
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
-      this._recorderSubscription = myModuleEvt.addListener('rn-recordback', callback);
+      this._recorderSubscription = myModuleEvt.addListener(
+        'rn-recordback',
+        callback,
+      );
     }
   };
 
@@ -184,7 +189,9 @@ class AudioRecorderPlayer {
    * Set listener from native module for player.
    * @returns {callBack((e: PlayBackType): void)}
    */
-  addPlayBackListener = (callback: ((playbackMeta: PlayBackType) => void)): void => {
+  addPlayBackListener = (
+    callback: (playbackMeta: PlayBackType) => void,
+  ): void => {
     if (Platform.OS === 'android')
       this._playerSubscription = DeviceEventEmitter.addListener(
         'rn-playback',
@@ -193,7 +200,10 @@ class AudioRecorderPlayer {
     else {
       const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
 
-      this._playerSubscription = myModuleEvt.addListener('rn-playback', callback);
+      this._playerSubscription = myModuleEvt.addListener(
+        'rn-playback',
+        callback,
+      );
     }
   };
 


### PR DESCRIPTION
The types for both listener functions were incorrect, causing a typescript error demonstrated here: https://github.com/hyochan/react-native-audio-recorder-player/issues/309

![image](https://user-images.githubusercontent.com/5509365/119029702-f5707700-b976-11eb-8dbc-39ff01de87ad.png)

This simply updates the signatures of the function to take in a callback function (that accepts a parameter of type `RecordBackType` or `PlayBackType`) and also adds some name changes