### PR TITLE
[iOS] Fix seekToPlayer method: it always seeked to 0.

### DIFF
--- a/ios/RNAudioRecorderPlayer.m
+++ b/ios/RNAudioRecorderPlayer.m
@@ -37,7 +37,7 @@ RCT_EXTERN_METHOD(startPlayer:(NSString*)path
 RCT_EXTERN_METHOD(resumePlayer:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(seekToPlayer:(nonnull NSNumber*) time
+RCT_EXTERN_METHOD(seekToPlayer:(nonnull double*) time
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 


### PR DESCRIPTION
How to reproduce:
- Start player
- Call `seekToPlayer` with any positive number (e.g. `4000`)
- Actual result: the player sought to 0 (the song is played from the start).
- Expected result: the player seeks to 4 seconds.

My Environment:
- Simulator: iPhone 12 Pro, iOS 14.4
- React native 0.64.1