### PR TITLE
Resolve #297 (3.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelogs
+- **[3.0.8]**
+  - [Bugfix/iOS] Fix crashing when stopping recorder when metering is enabled.
+     - Resolve [#297](https://github.com/hyochan/react-native-audio-recorder-player/issues/297)
+
 - **[3.0.7]**
   - [iOS] Set recording volume default to speaker.
 

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -254,23 +254,26 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
-        if (audioRecorder != nil) {
-            do {
-                audioRecorder.stop()
-                try recordingSession.setActive(false)
-
-                if (recordTimer != nil) {
-                    recordTimer!.invalidate()
-                    recordTimer = nil
-                }
-
-                resolve(audioFileURL?.absoluteString)
-            } catch {
-                reject("RNAudioPlayerRecorder", "Faled to stop recorder", nil)
-            }
+        if (audioRecorder == nil) {
+            reject("RNAudioPlayerRecorder", "Faled to stop recorder. It is already nil.", nil)
+            return
         }
+
+        audioRecorder.stop()
+
+        if (recordTimer != nil) {
+            recordTimer!.invalidate()
+            recordTimer = nil
+        }
+
+        resolve(audioFileURL?.absoluteString)
     }
 
+    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        if !flag {
+            print("Failed to stop recorder")
+        }
+    }
 
     /**********               Player               **********/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-audio-recorder-player",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "React Native Audio Recorder and Player.",
   "homepage": "https://github.com/dooboolab/react-native-audio-recorder-player",
   "main": "index.ts",


### PR DESCRIPTION
[Bugfix/iOS] Fix crash when stopping recorder when metering is enabled.
- Resolve [#297](https://github.com/hyochan/react-native-audio-recorder-player/issues/297)
