### PR TITLE
Fix minimum iOS deployment target

### DIFF
--- a/RNAudioRecorderPlayer.podspec
+++ b/RNAudioRecorderPlayer.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, "11.0"
+  s.ios.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/hyochan/react-native-audio-recorder-player.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,c,cc,cpp,m,mm,swift}"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/react-native": "^0.64.5",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.26.0",
+    "eslint-plugin-prettier": "^3.4.0",
     "flow-bin": "^0.151.0",
     "flowgen": "^1.14.1",
     "prettier": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,6 +866,13 @@ eslint-plugin-prettier@3.1.2:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-prettier@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^4.0.4:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"


### PR DESCRIPTION
This PR contemplates the addition of a minimal target for the ios_deployment_target, necessary for the pods. This resolves the issue #331 