### PR TITLE
fix println needs a message in android

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -155,7 +155,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         try {
             mediaRecorder!!.stop()
         } catch (stopException: RuntimeException) {
-            stopException.message?.let { Log.d(tag, it) }
+            stopException.message?.let { Log.d(tag,"" + it) }
             promise.reject("stopRecord", stopException.message)
         }
         mediaRecorder!!.release()


### PR DESCRIPTION
There is an issue in android that when you stop recording, native exception is thrown  `println needs a message in android`
[Here](https://stackoverflow.com/questions/6018633/nullpointerexception-println-needs-a-message-in-android) is more info about this issue
also [this](https://github.com/hyochan/react-native-audio-recorder-player/issues/283)