### PR TITLE
Fix permission request when one is already granted

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -38,8 +38,8 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     fun startRecorder(path: String, audioSet: ReadableMap?, meteringEnabled: Boolean, promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                    ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED &&
-                    ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                    (ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED ||
+                    ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)) {
                 ActivityCompat.requestPermissions((currentActivity)!!, arrayOf(
                         Manifest.permission.RECORD_AUDIO,
                         Manifest.permission.WRITE_EXTERNAL_STORAGE), 0)


### PR DESCRIPTION
When `WRITE_EXTERNAL_STORAGE` is already granted but not `RECORD_AUDIO` (or vice-versa), `startRecorder` will stop asking permission for `RECORD_AUDIO` as today a "and" is used instead of a "or" condition.

If user denies one of them, next call to `startRecorder` will lead to a hard crash with following stacktrace (if user still denies it):
java.lang.RuntimeException: setAudioSource failed.
	at android.media.MediaRecorder.setAudioSource(Native Method)
	at com.dooboolab.audiorecorderplayer.RNAudioRecorderPlayerModule.startRecorder(RNAudioRecorderPlayerModule.kt:62)
	at java.lang.reflect.Method.invoke(Native Method)