### PR TITLE
Fix playback of local files in iOS

### DIFF
--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -350,7 +350,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         }
 
         setAudioFileURL(path: path)
-        audioPlayerAsset = AVURLAsset(url: URL(string: path)!, options:["AVURLAssetHTTPHeaderFieldsKey": httpHeaders])
+        audioPlayerAsset = AVURLAsset(url: audioFileURL!, options:["AVURLAssetHTTPHeaderFieldsKey": httpHeaders])
         audioPlayerItem = AVPlayerItem(asset: audioPlayerAsset!)
 
         if (audioPlayer == nil) {


### PR DESCRIPTION
If I use this module to record some audio, and then try to play it back, I get the following error in the console.

```
2022-01-13 11:32:50.087002-0800 hilokal[4898:1045246] NSURLConnection finished with error - code -1002
```

I think this error was introduced in this PR: https://github.com/hyochan/react-native-audio-recorder-player/pull/405

This PR changes the AVURLAsset constructor back to use `audioFileURL`, as it did previously.