### PR TITLE
Fix #361: cannot pause recording after recorded once

### DIFF
--- a/Example/App.tsx
+++ b/Example/App.tsx
@@ -327,7 +327,7 @@ class Page extends Component<any, State> {
     );
 
     this.audioRecorderPlayer.addRecordBackListener((e: RecordBackType) => {
-      console.log('record-back', e);
+      // console.log('record-back', e);
       this.setState({
         recordSecs: e.currentPosition,
         recordTime: this.audioRecorderPlayer.mmssss(
@@ -340,7 +340,8 @@ class Page extends Component<any, State> {
 
   private onPauseRecord = async () => {
     try {
-      await this.audioRecorderPlayer.pauseRecorder();
+      const r = await this.audioRecorderPlayer.pauseRecorder();
+      console.log(r);
     } catch (err) {
       console.log('pauseRecord', err);
     }

--- a/index.ts
+++ b/index.ts
@@ -285,6 +285,7 @@ class AudioRecorderPlayer {
   stopRecorder = async (): Promise<string> => {
     if (this._isRecording) {
       this._isRecording = false;
+      this._hasPausedRecord = false;
 
       return RNAudioRecorderPlayer.stopRecorder();
     }


### PR DESCRIPTION
# Fix #361 

### Description:

Start record -> Pause record -> Stop record -> Start record again -> Pause record -> __Cannot pause record__ because `_hasPausedRecord` is still `true`

### Tested on Example

Before:

https://user-images.githubusercontent.com/31266357/172039275-9911439f-9dd3-4b3d-a7bb-71da12fb818a.mov

After:

https://user-images.githubusercontent.com/31266357/172039295-57fd9d05-26c7-44b0-a0de-b213ea41948b.mov


