### PR TITLE
 GOLD-5127-Remove-the-external-storage-permission-from-the-library

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,5 @@
           package="com.dooboolab.audiorecorderplayer">
     <!-- dooboolab -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>
   

--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -37,22 +37,11 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     @ReactMethod
     fun startRecorder(path: String, audioSet: ReadableMap?, meteringEnabled: Boolean, promise: Promise) {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                // TIRAMISU (33)
-                // https://github.com/hyochan/react-native-audio-recorder-player/issues/503
-                if (Build.VERSION.SDK_INT < 33 &&
-                        (ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED ||
-                        ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED))  {
-                    ActivityCompat.requestPermissions((currentActivity)!!, arrayOf(
-                            Manifest.permission.RECORD_AUDIO,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE), 0)
-                    promise.reject("No permission granted.", "Try again after adding permission.")
-                    return
-                } else if (ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-                    ActivityCompat.requestPermissions((currentActivity)!!, arrayOf(Manifest.permission.RECORD_AUDIO), 0)
-                    promise.reject("No permission granted.", "Try again after adding permission.")
-                    return
-                }
+            if ((ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO)) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions((currentActivity)!!, arrayOf(
+                        Manifest.permission.RECORD_AUDIO), 0)
+                promise.reject("No permission granted.", "Try again after adding permission.")
+                return
             }
         } catch (ne: NullPointerException) {
             Log.w(tag, ne.toString())


### PR DESCRIPTION
## Description
Remove the code to request external storage permission request. Since we are not using external storage for audio recordings we do not need the permission. 

## Solution
- Removed the permission from android manifest
- Removed the code to check for permission regarding external storage.
- Removed the code top request the user for external storage.