### PR TITLE
feat: add bitrate to ios and audio channels to android

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -72,6 +72,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             mediaRecorder!!.setAudioEncoder(if (audioSet.hasKey("AudioEncoderAndroid")) audioSet.getInt("AudioEncoderAndroid") else MediaRecorder.AudioEncoder.AAC)
             mediaRecorder!!.setAudioSamplingRate(if (audioSet.hasKey("AudioSamplingRateAndroid")) audioSet.getInt("AudioSamplingRateAndroid") else 48000)
             mediaRecorder!!.setAudioEncodingBitRate(if (audioSet.hasKey("AudioEncodingBitRateAndroid")) audioSet.getInt("AudioEncodingBitRateAndroid") else 128000)
+            mediaRecorder!!.setAudioChannels(if (audioSet.hasKey("AudioChannelsAndroid")) audioSet.getInt("AudioChannelsAndroid") else 2)
         } else {
             mediaRecorder!!.setAudioSource(MediaRecorder.AudioSource.MIC)
             mediaRecorder!!.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)

--- a/index.ts
+++ b/index.ts
@@ -126,10 +126,12 @@ export interface AudioSet {
   AVLinearPCMIsBigEndianKeyIOS?: boolean;
   AVLinearPCMIsFloatKeyIOS?: boolean;
   AVLinearPCMIsNonInterleavedIOS?: boolean;
+  AVEncoderBitRateKeyIOS?: number;
   OutputFormatAndroid?: OutputFormatAndroidType;
   AudioEncoderAndroid?: AudioEncoderAndroidType;
   AudioEncodingBitRateAndroid?: number;
   AudioSamplingRateAndroid?: number;
+  AudioChannelsAndroid?: number;
 }
 
 const pad = (num: number): string => {

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -158,6 +158,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         var sampleRate = audioSets["AVSampleRateKeyIOS"] as? Int
         var numberOfChannel = audioSets["AVNumberOfChannelsKeyIOS"] as? Int
         var audioQuality = audioSets["AVEncoderAudioQualityKeyIOS"] as? Int
+        var bitRate = audioSets["AVEncoderBitRateKeyIOS"] as? Int
 
         setAudioFileURL(path: path)
 
@@ -232,6 +233,10 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
             audioQuality = AVAudioQuality.medium.rawValue
         }
 
+        if (bitRate == nil) {
+            bitRate = 128000
+        }
+
         func startRecording() {
             let settings = [
                 AVSampleRateKey: sampleRate!,
@@ -241,7 +246,8 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                 AVLinearPCMBitDepthKey: avLPCMBitDepth ?? AVLinearPCMBitDepthKey.count,
                 AVLinearPCMIsBigEndianKey: avLPCMIsBigEndian ?? true,
                 AVLinearPCMIsFloatKey: avLPCMIsFloatKey ?? false,
-                AVLinearPCMIsNonInterleaved: avLPCMIsNonInterleaved ?? false
+                AVLinearPCMIsNonInterleaved: avLPCMIsNonInterleaved ?? false,
+                AVEncoderBitRateKey: bitRate!
             ] as [String : Any]
 
             do {


### PR DESCRIPTION
## Description
- add `bitRate` to iOS (default: 128000, same as Android)
- add `audioChannels` to Android (default: 2, same as iOS)