### PR TITLE
fix(android): update max sdk version for write external storage

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -38,9 +38,10 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     fun startRecorder(path: String, audioSet: ReadableMap?, meteringEnabled: Boolean, promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                // TIRAMISU (33)
-                // https://github.com/hyochan/react-native-audio-recorder-player/issues/503
-                if (Build.VERSION.SDK_INT < 33 &&
+                // On devices that run Android 10 (API level 29) or higher
+                // your app can contribute to well-defined media collections such as MediaStore.Downloads without requesting any storage-related permissions
+                // https://developer.android.com/about/versions/11/privacy/storage#permissions-target-11
+                if (Build.VERSION.SDK_INT < 29 &&
                         (ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED ||
                         ActivityCompat.checkSelfPermission(reactContext, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED))  {
                     ActivityCompat.requestPermissions((currentActivity)!!, arrayOf(


### PR DESCRIPTION
Hello, If the version of device is Android 10 or higher, no longer need the "write external storage" permission.

You can read more by following this link:
https://developer.android.com/about/versions/11/privacy/storage#permissions-target-11
>Keep in mind that, on devices that run Android 10 (API level 29) or higher, your app can contribute to well-defined media collections such as MediaStore.Downloads without requesting any storage-related permissions. Learn more about how to [request only the necessary permissions](https://developer.android.com/training/data-storage/shared/media#request-permissions) when working with media files in your app.

resolve #544