### PR TITLE
fix(ios): currentPosition and duration may never equal during playing

### DIFF
--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -376,8 +376,21 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         }
 
         addPeriodicTimeObserver()
+        NotificationCenter.default.addObserver(self, selector: #selector(playerDidFinishPlaying), name: Notification.Name.AVPlayerItemDidPlayToEndTime, object: audioPlayer.currentItem)
         audioPlayer.play()
         resolve(audioFileURL?.absoluteString)
+    }
+    
+    @objc
+    public func playerDidFinishPlaying(notification: Notification) {
+        if let playerItem = notification.object as? AVPlayerItem {
+            let duration = playerItem.duration.seconds * 1000
+            self.sendEvent(withName: "rn-playback", body: [
+                "isMuted": self.audioPlayer?.isMuted as Any,
+                "currentPosition": duration,
+                "duration": duration,
+            ])
+        }
     }
 
     @objc(stopPlayer:rejecter:)


### PR DESCRIPTION
## Problem
When play a remote file on iOS, `currentPosition` may never get to `duration`, which makes it difficult to know whether the playing is end.

## Solution
Add an observer to native player end event, and in that observer, force trigger another playback event, where `currentPosition` is set to be `duration`. Note that at this moment, `playerItem.currentTime` is still smaller than `duration`, so we cannot use that value.

may fix #328