### PR TITLE
Fix crash for invalid URL

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -264,7 +264,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                  * Reset player.
                  */
                 Log.d(tag, "Plays completed.")
-                mTimer!!.cancel()
+                mTimer?.cancel()
                 mp.stop()
                 mp.reset()
                 mp.release()


### PR DESCRIPTION
mTimer!!.cancel() was causing a crash when the URL was not a valid audio file. Have changed it to mTimer?.cancel().