### PR TITLE
Fix race conditions in iOS

### DIFF
--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -98,12 +98,14 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         recordTimer?.invalidate()
         recordTimer = nil;
 
-        if (audioRecorder == nil) {
-            return reject("RNAudioPlayerRecorder", "Recorder is not recording", nil)
-        }
+        DispatchQueue.main.async {
+            if (self.audioRecorder == nil) {
+                return reject("RNAudioPlayerRecorder", "Recorder is not recording", nil)
+            }
 
-        audioRecorder.pause()
-        resolve("Recorder paused!")
+            self.audioRecorder.pause()
+            resolve("Recorder paused!")
+        }
     }
 
     @objc(resumeRecorder:rejecter:)
@@ -111,17 +113,18 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
-        if (audioRecorder == nil) {
-            return reject("RNAudioPlayerRecorder", "Recorder is nil", nil)
+        DispatchQueue.main.async {
+            if (self.audioRecorder == nil) {
+                return reject("RNAudioPlayerRecorder", "Recorder is nil", nil)
+            }
+
+            self.audioRecorder.record()
+
+            if (self.recordTimer == nil) {
+                self.startRecorderTimer()
+            }
+            resolve("Recorder paused!")
         }
-
-        audioRecorder.record()
-
-        if (recordTimer == nil) {
-            startRecorderTimer()
-        }
-
-        resolve("Recorder paused!")
     }
 
     @objc
@@ -336,14 +339,16 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
             recordTimer = nil
         }
 
-        if (audioRecorder == nil) {
-            reject("RNAudioPlayerRecorder", "Failed to stop recorder. It is already nil.", nil)
-            return
+        DispatchQueue.main.async {
+            if (self.audioRecorder == nil) {
+                reject("RNAudioPlayerRecorder", "Failed to stop recorder. It is already nil.", nil)
+                return
+            }
+
+            self.audioRecorder.stop()
+
+            resolve(self.audioFileURL?.absoluteString)
         }
-
-        audioRecorder.stop()
-
-        resolve(audioFileURL?.absoluteString)
     }
 
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -24,7 +24,6 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
     var audioPlayerAsset: AVURLAsset!
     var audioPlayerItem: AVPlayerItem!
     var audioPlayer: AVPlayer!
-    var playTimer: Timer?
     var timeObserverToken: Any?
 
     override init() {
@@ -80,15 +79,15 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
 
     @objc(startRecorderTimer)
     func startRecorderTimer() -> Void {
-        DispatchQueue.main.async {
-            self.recordTimer = Timer.scheduledTimer(
-                timeInterval: self.subscriptionDuration,
-                target: self,
-                selector: #selector(self.updateRecorderProgress),
-                userInfo: nil,
-                repeats: true
-            )
-        }
+        let timer = Timer(
+            timeInterval: self.subscriptionDuration,
+            target: self,
+            selector: #selector(self.updateRecorderProgress),
+            userInfo: nil,
+            repeats: true
+        )
+        RunLoop.main.add(timer, forMode: .default)
+        self.recordTimer = timer
     }
 
     @objc(pauseRecorder:rejecter:)
@@ -96,12 +95,12 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
+        recordTimer?.invalidate()
+        recordTimer = nil;
+
         if (audioRecorder == nil) {
             return reject("RNAudioPlayerRecorder", "Recorder is not recording", nil)
         }
-
-        recordTimer?.invalidate()
-        recordTimer = nil;
 
         audioRecorder.pause()
         resolve("Recorder paused!")
@@ -332,17 +331,17 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
+        if (recordTimer != nil) {
+            recordTimer!.invalidate()
+            recordTimer = nil
+        }
+
         if (audioRecorder == nil) {
             reject("RNAudioPlayerRecorder", "Failed to stop recorder. It is already nil.", nil)
             return
         }
 
         audioRecorder.stop()
-
-        if (recordTimer != nil) {
-            recordTimer!.invalidate()
-            recordTimer = nil
-        }
 
         resolve(audioFileURL?.absoluteString)
     }


### PR DESCRIPTION
There were a few race conditions in the multithreaded code in RNAudioRecorderPlayer.swift.

`self.recordTimer` is set from the main thread. If caller invokes `startRecoder` and then subsequently `stopRecorder`, there is no guarantee that `self.recordTimer` will be set in time. This will result in "ghost" rn-recordback events being sent to the React Native thread.

To resolve this, this PR creates the timers on the react-native bridge thread, and then manually adds them to the main thread's run loop.

`self.audioRecorder` has a similar issue. It's created on the main thread, but then `stopPlayer` checks its value on the bridge thread. To resolve the race condition here, this PR dispatches the check on the main thread 