### PR TITLE
Add isFinished to rn-playback event

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -235,6 +235,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                             val obj = Arguments.createMap()
                             obj.putInt("duration", mp.duration)
                             obj.putInt("currentPosition", mp.currentPosition)
+                            obj.putBoolean("isFinished", false);
                             sendEvent(reactContext, "rn-playback", obj)
                         } catch (e: IllegalStateException) {
                             // IllegalStateException 처리
@@ -259,6 +260,7 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
                 val obj = Arguments.createMap()
                 obj.putInt("duration", mp.duration)
                 obj.putInt("currentPosition", mp.currentPosition)
+                obj.putBoolean("isFinished", true);
                 sendEvent(reactContext, "rn-playback", obj)
                 /**
                  * Reset player.

--- a/index.ts
+++ b/index.ts
@@ -150,6 +150,7 @@ export type PlayBackType = {
   isMuted?: boolean;
   currentPosition: number;
   duration: number;
+  isFinished: boolean;
 };
 
 class AudioRecorderPlayer {
@@ -320,7 +321,7 @@ class AudioRecorderPlayer {
       this._playerCallback(event);
     }
 
-    if (event.currentPosition === event.duration) {
+    if (event.isFinished) {
       this.stopPlayer();
     }
   };

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -365,6 +365,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                     "isMuted": self.audioPlayer.isMuted,
                     "currentPosition": self.audioPlayerItem.currentTime().seconds * 1000,
                     "duration": self.audioPlayerItem.asset.duration.seconds * 1000,
+                    "isFinished": false,
                 ])
             }
         }
@@ -418,6 +419,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                 "isMuted": self.audioPlayer?.isMuted as Any,
                 "currentPosition": duration,
                 "duration": duration,
+                "isFinished": true,
             ])
         }
     }


### PR DESCRIPTION
The purpose of this PR is to support chunked transfer-encoded HTTP requests, such as those returned from OpenAI and ElevenLabs Text-to-speech APIs.

Since these http requests don't contain a content-length, we can't rely on the duration to determine when they have finished.