### PR TITLE
Assign default file extension based on audio format

### DIFF
--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -388,15 +388,15 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
         private var tag = "RNAudioRecorderPlayer"
         private var defaultFileName = "sound.mp4"
         private var defaultFileExtensions = listOf(
-            "mp4", // DEFAULT = 0,
-            "3gp", // THREE_GPP,
-            "mp4", // MPEG_4,
-            "amr", // AMR_NB,
-            "amr", // AMR_WB,
-            "aac", // AAC_ADIF,
-            "aac", // AAC_ADTS,
-            "rtp", // OUTPUT_FORMAT_RTP_AVP,
-            "ts",  // MPEG_2_TSMPEG_2_TS,
+            "mp4", // DEFAULT = 0
+            "3gp", // THREE_GPP
+            "mp4", // MPEG_4
+            "amr", // AMR_NB
+            "amr", // AMR_WB
+            "aac", // AAC_ADIF
+            "aac", // AAC_ADTS
+            "rtp", // OUTPUT_FORMAT_RTP_AVP
+            "ts",  // MPEG_2_TSMPEG_2_TS
             "webm",// WEBM
             "xxx", // UNUSED
             "ogg", // OGG

--- a/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/dooboolab.audiorecorderplayer/RNAudioRecorderPlayerModule.kt
@@ -60,7 +60,13 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
             promise.reject("No permission granted.", "Try again after adding permission.")
             return
         }
-        audioFileURL = if (((path == "DEFAULT"))) "${reactContext.cacheDir}/$defaultFileName" else path
+
+        var outputFormat = if (audioSet != null && audioSet.hasKey("OutputFormatAndroid"))
+            audioSet.getInt("OutputFormatAndroid")
+        else
+            MediaRecorder.OutputFormat.MPEG_4
+
+        audioFileURL = if (((path == "DEFAULT"))) "${reactContext.cacheDir}/sound.${defaultFileExtensions.get(outputFormat)}" else path
         _meteringEnabled = meteringEnabled
 
         if (mediaRecorder == null) {
@@ -69,14 +75,14 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
 
         if (audioSet != null) {
             mediaRecorder!!.setAudioSource(if (audioSet.hasKey("AudioSourceAndroid")) audioSet.getInt("AudioSourceAndroid") else MediaRecorder.AudioSource.MIC)
-            mediaRecorder!!.setOutputFormat(if (audioSet.hasKey("OutputFormatAndroid")) audioSet.getInt("OutputFormatAndroid") else MediaRecorder.OutputFormat.MPEG_4)
+            mediaRecorder!!.setOutputFormat(outputFormat)
             mediaRecorder!!.setAudioEncoder(if (audioSet.hasKey("AudioEncoderAndroid")) audioSet.getInt("AudioEncoderAndroid") else MediaRecorder.AudioEncoder.AAC)
             mediaRecorder!!.setAudioSamplingRate(if (audioSet.hasKey("AudioSamplingRateAndroid")) audioSet.getInt("AudioSamplingRateAndroid") else 48000)
             mediaRecorder!!.setAudioEncodingBitRate(if (audioSet.hasKey("AudioEncodingBitRateAndroid")) audioSet.getInt("AudioEncodingBitRateAndroid") else 128000)
             mediaRecorder!!.setAudioChannels(if (audioSet.hasKey("AudioChannelsAndroid")) audioSet.getInt("AudioChannelsAndroid") else 2)
         } else {
             mediaRecorder!!.setAudioSource(MediaRecorder.AudioSource.MIC)
-            mediaRecorder!!.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            mediaRecorder!!.setOutputFormat(outputFormat)
             mediaRecorder!!.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
             mediaRecorder!!.setAudioEncodingBitRate(128000)
             mediaRecorder!!.setAudioSamplingRate(48000)
@@ -381,5 +387,19 @@ class RNAudioRecorderPlayerModule(private val reactContext: ReactApplicationCont
     companion object {
         private var tag = "RNAudioRecorderPlayer"
         private var defaultFileName = "sound.mp4"
+        private var defaultFileExtensions = listOf(
+            "mp4", // DEFAULT = 0,
+            "3gp", // THREE_GPP,
+            "mp4", // MPEG_4,
+            "amr", // AMR_NB,
+            "amr", // AMR_WB,
+            "aac", // AAC_ADIF,
+            "aac", // AAC_ADTS,
+            "rtp", // OUTPUT_FORMAT_RTP_AVP,
+            "ts",  // MPEG_2_TSMPEG_2_TS,
+            "webm",// WEBM
+            "xxx", // UNUSED
+            "ogg", // OGG
+        )
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,8 @@ export enum OutputFormatAndroidType {
   OUTPUT_FORMAT_RTP_AVP,
   MPEG_2_TS,
   WEBM,
+  UNUSED,
+  OGG,
 }
 
 export enum AudioEncoderAndroidType {
@@ -44,6 +46,7 @@ export enum AudioEncoderAndroidType {
   HE_AAC,
   AAC_ELD,
   VORBIS,
+  OPUS,
 }
 
 export enum AVEncodingOption {


### PR DESCRIPTION
I am using this library to record ogg/opus files, however, the default file name was always "sound.mp4" or "sound.m4a", regardless of the audio format.

To fix this, I tried passing in a custom path to startRecord, with the correct file extension, however a native extension is required to get the proper path to the cache directory on Android.

Since a native modification is required anyway, I decided to modify this module to just pick a reasonable default file extension for the giving audio format.

I also added the proper OGG / OPUS types for Android to index.ts. These types are supported as of apiVersion 29.

