### PR TITLE
If startRecorder fails, the recorder is left in an invalid, unrecoverable state

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -248,11 +248,16 @@ class AudioRecorderPlayer {
     if (!this._isRecording) {
       this._isRecording = true;
 
-      return RNAudioRecorderPlayer.startRecorder(
-        uri ?? 'DEFAULT',
-        audioSets,
-        meteringEnabled ?? false,
-      );
+      try {
+        return await RNAudioRecorderPlayer.startRecorder(
+          uri ?? 'DEFAULT',
+          audioSets,
+          meteringEnabled ?? false,
+        );
+      } catch (error: any) {
+        this._isRecording = false;
+        throw error;
+      }
     }
 
     return 'Already recording';


### PR DESCRIPTION
It's common for either `MediaRecorder.start()` or `MediaRecorder.prepare()` to fail if the device doesn't support the requested codec, or there is some problem with the arguments.

Currently, if this happens, the recorder is left in an invalid state:

### `index.ts`
If an error occurs, this._isRecording is still set to `true`, which is incorrect. This PR will catch an error and reset this boolean to `false`


### `RNAudioRecorderPlayerModule.kt`
If an error occurs,  `this.mediaRecorder` will be set to partially or incorrectly initialized object. The next time `startRecord()` is called, this stale object will be reused, which caused a secondary (and more confusing) error.

To fix this, `startRecord` will catch any initialization error and reset `this.mediaRecorder` to null.
