### PR TITLE
fix: RN 0.79 audio recording failing most of the time

### DIFF
--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -288,10 +288,10 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
                     do {
                         try self.audioSession.setCategory(.playAndRecord, mode: avMode, options: [.defaultToSpeaker, .allowBluetooth])
                         try self.audioSession.setActive(true)
+                        startRecording()
                       } catch let error {
                         reject("RNAudioPlayerRecorder", "Failed to activate audio session", error)
                       }
-                    startRecording()
                 } else {
                     reject("RNAudioPlayerRecorder", "Record permission not granted", nil)
                 }

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -150,7 +150,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
     }
 
     // handle interrupt events
-    @objc 
+    @objc
     func handleAudioSessionInterruption(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
             let interruptionType = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt else {
@@ -282,21 +282,20 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
 
         audioSession = AVAudioSession.sharedInstance()
 
-        do {
-            try audioSession.setCategory(.playAndRecord, mode: avMode, options: [AVAudioSession.CategoryOptions.defaultToSpeaker, AVAudioSession.CategoryOptions.allowBluetooth])
-            try audioSession.setActive(true)
-
-            audioSession.requestRecordPermission { granted in
-                DispatchQueue.main.async {
-                    if granted {
-                        startRecording()
-                    } else {
-                        reject("RNAudioPlayerRecorder", "Record permission not granted", nil)
-                    }
+        audioSession.requestRecordPermission { granted in
+            DispatchQueue.main.async {
+                if granted {
+                    do {
+                        try self.audioSession.setCategory(.playAndRecord, mode: avMode, options: [.defaultToSpeaker, .allowBluetooth])
+                        try self.audioSession.setActive(true)
+                      } catch let error {
+                        reject("RNAudioPlayerRecorder", "Failed to activate audio session", error)
+                      }
+                    startRecording()
+                } else {
+                    reject("RNAudioPlayerRecorder", "Record permission not granted", nil)
                 }
             }
-        } catch {
-            reject("RNAudioPlayerRecorder", "Failed to record", nil)
         }
     }
 
@@ -385,7 +384,7 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
         audioPlayer.play()
         resolve(audioFileURL?.absoluteString)
     }
-    
+
     @objc
     public func playerDidFinishPlaying(notification: Notification) {
         if let playerItem = notification.object as? AVPlayerItem {


### PR DESCRIPTION
This PR addresses an issue that seems to have appeared with React Native `0.79.0` and onwards, related to how RN loads native modules I believe and how it's expected that their internal methods are meant to be executed. 

I can confirm that the issue is happening on `0.79.3` specifically on iOS, new architecture (have not tested on the old one).

Namely, each time `startRecording` is invoked it is going to fail about 70% of the time with an ambiguous error that requires further inspection. 

The line that actually fails is [this one here](https://github.com/hyochan/react-native-audio-recorder-player/blob/97f6012c1a0b4c0fe8808d7743a8f9a57772aeff/ios/RNAudioRecorderPlayer.swift#L267). More often than not, this should happen if:

- The `audioSession` is not active or configured properly
- Something else is recording and blocking the entire process

Sadly, since `AVAudioRecorder.record()` fails silently and returns `false` — even when the app has microphone permissions and the session appears configured correctly this is again a bit nasty to debug. But with attaching some observers to check the `audioSession`'s configuration we can see that it is indeed not active at the time of trying to start the recording.

The main reason why this is happening I believe is pretty much [this](https://github.com/reactwg/react-native-new-architecture/discussions/285). While we could previously get away with native modules being initialized and their methods run outside of the main thread specifically, since now native modules are tied to `mqt_native` we can no longer reliably do that and what ends up happening is we encounter a race condition where the session is simply not active by the time we try to start the recording. You can also see [this](https://github.com/facebook/react-native/pull/45324) for reference. The reason why this started happening in `0.79` and onwards and not before is I believe the fact that this strictness is enforced.

The fix is simple, moving the configuration/activation phase of the `audioSession` down into the main thread execution block and we're good to go.
