### PR TITLE
chore: Remove `nitrogen/` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,6 @@ ios/generated
 android/generated
 
 # React Native Nitro Modules
-nitrogen/
 build.log
 ios-build.log
 kotlin-compiler-*


### PR DESCRIPTION
This way you can pull off of github without the need of a separate script. 