### PR TITLE
fix(android): return file path from stopRecorder

### DIFF
--- a/android/src/main/java/com/margelo/nitro/audiorecorderplayer/AudioRecorderPlayer.kt
+++ b/android/src/main/java/com/margelo/nitro/audiorecorderplayer/AudioRecorderPlayer.kt
@@ -24,6 +24,7 @@ import kotlin.math.log10
 class HybridAudioRecorderPlayer : HybridAudioRecorderPlayerSpec() {
     private var mediaRecorder: MediaRecorder? = null
     private var mediaPlayer: MediaPlayer? = null
+    private var currentRecordingPath: String? = null
 
     private var recordTimer: Timer? = null
     private var playTimer: Timer? = null
@@ -103,6 +104,8 @@ class HybridAudioRecorderPlayer : HybridAudioRecorderPlayerSpec() {
                 val fileName = "sound_${System.currentTimeMillis()}.mp4"
                 File(dir, fileName).absolutePath
             }
+            // Store the recording path
+            currentRecordingPath = filePath
 
             // Initialize MediaRecorder
             mediaRecorder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -277,7 +280,9 @@ class HybridAudioRecorderPlayer : HybridAudioRecorderPlayerSpec() {
                     stopRecordTimer()
                 }
 
-                promise.resolve("Recorder stopped")
+                val path = currentRecordingPath ?: "Unknown path"
+                currentRecordingPath = null // Clear after returning
+                promise.resolve(path)
             } catch (e: Exception) {
                 mediaRecorder?.release()
                 mediaRecorder = null

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -260,9 +260,28 @@ const App = () => {
       setIsRecording(false);
       setIsPaused(false);
       setIsStopLoading(false);
-      console.log('Recording stopped:', result);
-      console.log('Final recorded duration:', finalTime);
-      console.log('Actual recorded milliseconds:', recordSecs);
+
+      // Log the recording path returned from stopRecorder
+      console.log('🎤 ============================================');
+      console.log('🎤 Recording stopped successfully!');
+      console.log('🎤 Returned file path:', result);
+      console.log('🎤 Type of result:', typeof result);
+      console.log(
+        '🎤 Is path valid?:',
+        result && result !== 'Recorder stopped'
+      );
+      console.log('🎤 Final recorded duration:', finalTime);
+      console.log('🎤 Actual recorded milliseconds:', recordSecs);
+      console.log('🎤 ============================================');
+
+      // Show alert with the returned path for easy verification
+      if (Platform.OS === 'android') {
+        Alert.alert(
+          'Recording Stopped',
+          `File saved at:\n${result}\n\nDuration: ${finalTime}`,
+          [{ text: 'OK' }]
+        );
+      }
     } catch (error) {
       console.error('Stop record error:', error);
       setIsStopLoading(false);


### PR DESCRIPTION
## Summary
Fixes #693 - `stopRecorder` now returns the actual file path instead of "Recorder stopped"

## Test Plan
- Start recording on Android
- Stop recording
- Verify the returned value is the file path (e.g., `/data/user/0/com.x/files/sound_1756843050671.mp4`)